### PR TITLE
Cambio a la manera de mostrar las imágenes de los episodios.

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -23,12 +23,22 @@ body {
 }
 
 .carousel-item .episodeImg {
-    height: 700px;
+    height: 500px;
     position: relative;
+    object-fit: cover;
+    object-position: 100% 40%;
 }
 
 .episodeImg {
-    height: 400px;    
+    height: 350px;    
+    object-fit: cover;
+    object-position: 100% 20%;
+}
+
+.epiDetail {
+    height: 400px;
+    object-fit: cover;
+    object-position: 100% 50%;
 }
 
 .epiList_cont .card-body {

--- a/episodio.html
+++ b/episodio.html
@@ -1,6 +1,6 @@
 <div class="container">
   <article class="card mb-3">
-      <img class="img-fluid" src="{{ episode_image_url }}" />
+      <img class="img-fluid epiDetail" src="{{ episode_image_url }}" />
       <div class="card-body">
           <h5 class="card-title">{{ episode_title }} <span class='playButton' data-toggle='tooltip' title='Reproducir episodio'><i class="fas fa-play"></i></span></h5>
           <p class="card-text">{{ episode_description }}</p>


### PR DESCRIPTION
Ahora las imágenes se ajustan a su contenedor. Se intentó hacer que tengan un posicionamiento relativamente correcto pero no se puede asegurar que en todas las fotos se muestren las caras o no se corten partes importantes.

La manera correcta de hacer esto sería disponer de las imágenes en distintas resoluciones y según la sección del sitio cargar la imágen correspondiente.

Ticket #15 